### PR TITLE
INVT-11610: Update snakeyaml to version 2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,3 +106,4 @@ tasks.processResources {
         file("build/resources/main/gradle.properties").writeText("version=${project.version}")
     }
 }
+ext["snakeyaml.version"] = "2.2"


### PR DESCRIPTION
This one is a derived dependency of spring-boot, and we are already in the latest spring boot version. This is a false positive as stated here https://github.com/spring-projects/spring-boot/issues/33457 and since we are not doing any manual yaml parsing. However, we can update to v2.2 to completely remove the snakeyaml 1.33 from our jars.